### PR TITLE
feat: container friendly logger

### DIFF
--- a/src/shared/logging/__tests__/containerFriendlyLogger.test.ts
+++ b/src/shared/logging/__tests__/containerFriendlyLogger.test.ts
@@ -1,0 +1,56 @@
+import { trimWhitespace, friendlyLogEntry } from '../containerFriendlyLogger';
+import { EOL } from 'os';
+
+describe(trimWhitespace.name, () => {
+  it('should work', () => {
+    expect(trimWhitespace(false)).toBe(false);
+    expect(trimWhitespace('')).toBe('');
+    expect(trimWhitespace('x  x')).toBe('x  x');
+    expect(trimWhitespace('  x  x  ')).toBe('x  x');
+    expect(trimWhitespace(` ${EOL} x  x  `)).toBe('x  x');
+    expect(trimWhitespace(` ${EOL} x  x ${EOL} `)).toBe('x  x');
+    expect(trimWhitespace(` - x  x ${EOL} `)).toBe('- x  x');
+  });
+});
+
+describe(friendlyLogEntry.name, () => {
+  it('should work', () => {
+    expect(friendlyLogEntry()).toEqual('[]');
+    expect(friendlyLogEntry(undefined)).toEqual('["undefined"]');
+    expect(friendlyLogEntry(null)).toEqual('["null"]');
+    expect(
+      friendlyLogEntry(() => {
+        return;
+      })
+    ).toEqual('["[Function]"]');
+    expect(friendlyLogEntry('  x  x  ')).toEqual('["x  x"]');
+    const err = new Error();
+    expect(friendlyLogEntry(err)).toEqual(
+      '[' + JSON.stringify(`${err.stack}`) + ']'
+    );
+    expect(friendlyLogEntry({ someValue: 1 })).toEqual('["{ someValue: 1 }"]');
+    expect(
+      friendlyLogEntry({
+        value: {
+          secondLevel: {
+            thirdLevel: [1, 2, 3],
+            another: {
+              andNotDeeperThanThat: {
+                goDeeper: 'Value',
+                another: { theDepths: {} },
+              },
+            },
+          },
+        },
+      })
+    ).toEqual(
+      '["{ value:\\n   { secondLevel:\\n      { thirdLevel: [ 1, 2, 3 ],\\n        another: { andNotDeeperThanThat: [Object] } } } }"]'
+    );
+    expect(friendlyLogEntry(false)).toEqual('[false]');
+    expect(friendlyLogEntry(123)).toEqual('[123]');
+    expect(friendlyLogEntry(null)).toEqual('["null"]');
+    expect(friendlyLogEntry('  👍 Works with emojis  ❌  ', EOL)).toEqual(
+      '["👍 Works with emojis  ❌"]'
+    );
+  });
+});

--- a/src/shared/logging/containerFriendlyLogger.ts
+++ b/src/shared/logging/containerFriendlyLogger.ts
@@ -1,0 +1,57 @@
+import { BasicLogger, createBasicLogger } from '.';
+import util from 'util';
+
+export function trimWhitespace(arg: unknown) {
+  if (typeof arg === 'string') {
+    return arg
+      .replace(/^(\s*\n\s*|\s)+/gu, '')
+      .replace(/(\s*\n\s*|\s)+$/gu, '');
+  }
+  return arg;
+}
+
+export function isNotEmptyOrLineBreak(arg: unknown) {
+  if (typeof arg === 'string') {
+    const trimmed = arg;
+    if (trimmed.length === 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const allowedTypes = ['string', 'number', 'boolean'];
+
+export function transformValue(arg: unknown) {
+  if (allowedTypes.includes(typeof arg)) {
+    return arg;
+  }
+  return util.inspect(arg, {
+    compact: true,
+    colors: false,
+    depth: 3,
+  });
+}
+
+export function friendlyLogEntry(...args: unknown[]) {
+  return JSON.stringify(
+    args
+      .map(trimWhitespace)
+      .filter(isNotEmptyOrLineBreak)
+      .map(transformValue)
+  );
+}
+
+/**
+ * Converts the whole logging entry into a single JSON string which
+ * makes this compatible with Docker and allow multiline data like
+ * exceptions to be retained within same log entry.
+ */
+export const createContainerFriendlyLogger = (): BasicLogger => {
+  const logger = createBasicLogger();
+  return Object.freeze({
+    log: (...args: unknown[]) => logger.log(friendlyLogEntry(...args)),
+    warn: (...args: unknown[]) => logger.warn(friendlyLogEntry(...args)),
+    error: (...args: unknown[]) => logger.error(friendlyLogEntry(...args)),
+  });
+};


### PR DESCRIPTION
The problem with current logger is that it can have multilines which breaks single entry to multiple in Google Cloud Console logs and `docker logs`.

What we going to do is use this logger instead for PROD.